### PR TITLE
doc: Update Kotti RPC endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Please see [bootnodes.txt](bootnodes.txt) if you fail connecting to the network.
 - Block Explorer:
   - http://kottiexplorer.ethernode.io/
 - Open RPC Endpoints:
-  - https://kotti.ethereumclassic.network
+  - https://www.ethercluster.com/kotti
 - Gitter: https://gitter.im/goerli/kotti/
 
 Please see [kotti.genesis](geth/kotti.genesis) for a genesis file compatible with Multi Geth.


### PR DESCRIPTION
Deleted old RPC endpoint as we don't support it no more and added the new Kotti RPC endpoint from our Ethercluster project.