### PR TITLE
Add ethereum-faucet

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Run `geth --goerli` or `besu --network=goerli` to sync the testnet. The Chain ID
   - https://faucet.goerli.mudit.blog/
   - https://faucets.chain.link/goerli (No social media account required)
   - https://goerli-faucet.pk910.de/ (PoW powered, No social media account required)
+  - https://goerli-faucet.com/ ([Open Source](https://github.com/ayanamitech/ethereum-faucet), Telegram Bot authenticated, No social media account required)
 - Open RPC Endpoints:
   - https://goerli.prylabs.net
   - https://rpc.goerli.mudit.blog


### PR DESCRIPTION
Add [goerli-faucet.com](https://goerli-faucet.com) which is powered by open source [ethereum-faucet](https://github.com/ayanamitech/ethereum-faucet) backend.

More info about faucet: https://github.com/poanetwork/poa-faucet/pull/32